### PR TITLE
Fix different URL color in Firefox

### DIFF
--- a/pcgamingwiki-dark-theme.user.css
+++ b/pcgamingwiki-dark-theme.user.css
@@ -63,8 +63,13 @@
 	.template-infobox, .suggestions-special .special-query, .suggestions-result {
 		color: #ccc;
 	}
-	a, a:-webkit-any-link {
+	a:-webkit-any-link {
 		color: #73a8ff;
+	}
+	a {
+		text-decoration: none;
+		color: #73a8ff;
+		background: none;
 	}
 	.mw-parser-output a.external {
 		color: #5788d9;


### PR DESCRIPTION
In Firefox, there are different URL color, less visible...
![0](https://user-images.githubusercontent.com/14265316/188719402-e81ae320-92fa-4cac-b352-203d024b64f4.jpg)
...than in Chromium:
![1](https://user-images.githubusercontent.com/14265316/188719384-0fa57999-e175-445b-9b52-dcdcb9319628.jpg)
I tried to fix that, feel free to give any suggestions.