### PR TITLE
Fix site notice background color

### DIFF
--- a/pcgamingwiki-dark-theme.user.css
+++ b/pcgamingwiki-dark-theme.user.css
@@ -37,6 +37,9 @@
 		background-color: #313235;
 		color: #ccc;
 	}
+	#site-notice {
+		background-color: #794300;
+	}
 	#main-content, .page-Home div#body-content input[type="search"], .page-Home .home-subheader{
 		background-color: #222;
 	}


### PR DESCRIPTION
It's too bright by default.
![0](https://user-images.githubusercontent.com/14265316/205770694-2900d67b-7dc2-4ca8-82e9-4bfa59331a91.jpg)